### PR TITLE
Show name of current profile in header

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -57,6 +57,7 @@ export class AuthComponent implements OnInit, OnDestroy {
       // runs upon receiving oauthCode from the redirect
       this.authService.changeAuthState(AuthState.AwaitingAuthentication);
       this.restoreOrgDetailsFromLocalStorage();
+      this.restoreProfileNameFromLocalStorage();
       this.logger.info('AuthComponent: Obtained authorisation code from Github');
       this.fetchAccessToken(oauthCode, state);
     }
@@ -151,6 +152,11 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo = window.localStorage.getItem('dataRepo');
     this.githubService.storeOrganizationDetails(org, dataRepo);
     this.phaseService.setSessionData();
+  }
+
+  private restoreProfileNameFromLocalStorage() {
+    const profileName = window.localStorage.getItem('profileName');
+    this.phaseService.setProfileName(profileName);
   }
 
   /**

--- a/src/app/auth/session-selection/session-selection.component.ts
+++ b/src/app/auth/session-selection/session-selection.component.ts
@@ -16,6 +16,7 @@ export class SessionSelectionComponent implements OnInit {
   // isSettingUpSession is used to indicate whether CATcher is in the midst of setting up the session.
   isSettingUpSession: boolean;
   profileForm: FormGroup;
+  selectedProfile: Profile;
 
   @Input() urlEncodedSessionName: string;
 
@@ -36,12 +37,13 @@ export class SessionSelectionComponent implements OnInit {
   }
 
   /**
-   * Fills the login form with data from the given Profile.
+   * Fills the login form with data from the given Profile and sets selectedProfile
    * @param profile - Profile selected by the user.
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.repoName);
     this.sessionEmitter.emit(profile.repoName);
+    this.selectedProfile = profile;
   }
 
   setupSession() {
@@ -55,6 +57,7 @@ export class SessionSelectionComponent implements OnInit {
     // Persist session information in local storage
     window.localStorage.setItem('org', org);
     window.localStorage.setItem('dataRepo', dataRepo);
+    window.localStorage.setItem('profileName', this.selectedProfile.profileName);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
     this.logger.info(`SessionSelectionComponent: Selected Settings Repo: ${sessionInformation}`);

--- a/src/app/auth/session-selection/session-selection.component.ts
+++ b/src/app/auth/session-selection/session-selection.component.ts
@@ -62,6 +62,8 @@ export class SessionSelectionComponent implements OnInit {
 
     this.logger.info(`SessionSelectionComponent: Selected Settings Repo: ${sessionInformation}`);
 
+    this.phaseService.setProfileName(this.selectedProfile.profileName);
+
     this.phaseService.storeSessionData().subscribe(
       () => {
         try {

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -30,6 +30,8 @@ export class PhaseService {
   private repoName: string;
   private orgName: string;
 
+  private profileName: string;
+
   public sessionData: SessionData;
 
   private phaseRepoOwners = {
@@ -52,6 +54,18 @@ export class PhaseService {
     this.phaseRepoOwners.phaseTeamResponse = org;
     this.phaseRepoOwners.phaseTesterResponse = user;
     this.phaseRepoOwners.phaseModeration = org;
+  }
+
+  /**
+   * Stores the name of the profile
+   * @param profileName - name of the current profile
+   */
+  setProfileName(profileName: string) {
+    this.profileName = profileName;
+  }
+
+  getProfileName(): string {
+    return this.profileName;
   }
 
   /**

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -11,6 +11,7 @@
   <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase"
     >CATcher v{{ this.getVersion() }}</a
   >
+  <span id="profile-name-display" *ngIf="auth.isAuthenticated()">&nbsp;{{ phaseService.getProfileName() }}</span>
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
     ({{ this.getPhaseDescription(phaseService.currentPhase) }})
   </span>


### PR DESCRIPTION
Currently, users cannot see the name of the selected profile once they log in. The only way to check that they have selected the correct one is to log out and log in again. Although it is impossible for the user to log in with the wrong profile selected (as they will not be listed as a student in the other profile / the other profile will have no active phases), the users do not know this and hence they might want to check which profile is currently selected. 

I have changed the header to include the name of the profile, as seen in the screenshots below:

Here, the selected session is "CSXXXX PE":
<img width="959" alt="image" src="https://github.com/user-attachments/assets/4b341290-4f3b-4a1f-91d2-803d82491795" />

The header shows "CSXXXX PE":
<img width="958" alt="image" src="https://github.com/user-attachments/assets/210e1cec-5fd1-48be-888a-c6a1d9697531" />

