### PR TITLE
Change cursor when hovering over info icon

### DIFF
--- a/src/app/shared/issue/label/label.component.css
+++ b/src/app/shared/issue/label/label.component.css
@@ -31,3 +31,8 @@
   font-size: 1em;
   text-align: left;
 }
+
+.infoIcon:hover {
+  cursor: pointer;
+  color: #585858;
+}

--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -17,7 +17,7 @@
     </button>
 
     <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openDefinitionPage(value); $event.stopPropagation()">
-      <mat-icon style="font-size: 20px">info</mat-icon>
+      <mat-icon class="infoIcon" style="font-size: 20px">info</mat-icon>
     </button>
   </div>
 </mat-menu>

--- a/src/app/shared/label-dropdown/label-dropdown.component.css
+++ b/src/app/shared/label-dropdown/label-dropdown.component.css
@@ -17,3 +17,8 @@
   display: grid;
   grid-template-columns: auto 20%;
 }
+
+.infoIcon:hover {
+  cursor: pointer;
+  color: #585858;
+}

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -19,7 +19,7 @@
         </mat-option>
 
         <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
-          <mat-icon style="font-size: 20px">info</mat-icon>
+          <mat-icon class="infoIcon" style="font-size: 20px">info</mat-icon>
         </button>
       </div>
     </mat-select>


### PR DESCRIPTION
Typically, when users hover over an info icon, a tooltip should appear with the additional info. However, this is not the case in CATcher, and users have to click on the icon for the modal to show. However, the cursor does not change when the user hovers over it and there is no indication that the info icon is clickable:

https://github.com/user-attachments/assets/14d88388-810c-4f97-a2e7-a336b9809371

Hence it is quite counter-intuitive to the user. 

This modification changes the cursor to a pointer and darkens the info icon on hover, making it clear to users that the icon is clickable.

https://github.com/user-attachments/assets/f25e8461-eb0d-4ba5-8054-26e4c5e2fecc

