### PR TITLE
Show the number of issues of each label during bug reporting phase

### DIFF
--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.css
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.css
@@ -31,3 +31,9 @@
 .mat-column-severity {
   width: 23%;
 }
+
+.stats-div {
+  display: flex;
+  gap: 50px;
+  justify-content: start;
+}

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -32,6 +32,6 @@
   <app-issue-tables table_name="tableBugReporting" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
   <div class="type-stats">
     Label counts:
-    <p *ngFor="let label of this.typeCount | keyvalue">{{ label.key }}: {{ label.value }}</p>
+    <p *ngFor="let label of (typeCount$ | async).entries() | keyvalue">{{ label.key }}: {{ label.value }}</p>
   </div>
 </div>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -29,5 +29,14 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables table_name="tableBugReporting" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableBugReporting"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    (countChanged)="this.updateCount()"
+  ></app-issue-tables>
+  <div class="type-stats">
+    Label counts:
+    <p *ngFor="let label of this.typeCount | keyvalue">{{ label.key }}: {{ label.value }}</p>
+  </div>
 </div>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -30,8 +30,12 @@
   </mat-grid-list>
 
   <app-issue-tables table_name="tableBugReporting" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
-  <div class="type-stats">
-    Label counts:
-    <p *ngFor="let label of (typeCount$ | async).entries() | keyvalue">{{ label.key }}: {{ label.value }}</p>
+  <div class="stats-div">
+    <div class="type-stats">
+      <p *ngFor="let entry of this.typeCount | keyvalue">{{ entry.key }}: {{ entry.value }}</p>
+    </div>
+    <div class="severity-stats">
+      <p *ngFor="let entry of this.severityCount | keyvalue">{{ entry.key }}: {{ entry.value }}</p>
+    </div>
   </div>
 </div>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -29,12 +29,7 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables
-    table_name="tableBugReporting"
-    [headers]="this.displayedColumns"
-    [actions]="this.actionButtons"
-    (countChanged)="this.updateCount()"
-  ></app-issue-tables>
+  <app-issue-tables table_name="tableBugReporting" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
   <div class="type-stats">
     Label counts:
     <p *ngFor="let label of this.typeCount | keyvalue">{{ label.key }}: {{ label.value }}</p>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -15,11 +15,25 @@ export class PhaseBugReportingComponent implements OnInit {
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
+  typeCount: Map<string, number>;
+  severityCount: Map<string, number>;
+
   constructor(public permissions: PermissionService, public userService: UserService) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.typeCount = this.table.typeCount;
+    this.severityCount = this.table.severityCount;
+  }
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;
+  }
+
+  updateCount() {
+    this.typeCount = this.table.typeCount;
+    this.severityCount = this.table.severityCount;
+    console.log('EVENT DETECTED');
+    console.log(this.typeCount);
+    console.log(this.severityCount);
   }
 }

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -19,11 +19,20 @@ export class PhaseBugReportingComponent implements OnInit {
   typeCount$: Observable<Map<string, number>>;
   severityCount$: Observable<Map<string, number>>;
 
+  typeCount: Map<string, number> = new Map();
+  severityCount: Map<string, number> = new Map();
+
   constructor(public permissions: PermissionService, public userService: UserService) {}
 
   ngOnInit() {
     this.typeCount$ = this.table.typeCount$;
     this.severityCount$ = this.table.severityCount$;
+    this.typeCount$.subscribe((data) => {
+      this.typeCount = new Map(data);
+    });
+    this.severityCount$.subscribe((data) => {
+      this.severityCount = new Map(data);
+    });
   }
 
   applyFilter(filterValue: string) {

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -3,6 +3,7 @@ import { PermissionService } from '../core/services/permission.service';
 import { UserService } from '../core/services/user.service';
 import { TABLE_COLUMNS } from '../shared/issue-tables/issue-tables-columns';
 import { ACTION_BUTTONS, IssueTablesComponent } from '../shared/issue-tables/issue-tables.component';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-phase-bug-reporting',
@@ -15,12 +16,15 @@ export class PhaseBugReportingComponent implements OnInit {
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  typeCount: Map<string, number>;
-  severityCount: Map<string, number>;
+  typeCount$: Observable<Map<string, number>>;
+  severityCount$: Observable<Map<string, number>>;
 
   constructor(public permissions: PermissionService, public userService: UserService) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.typeCount$ = this.table.typeCount$;
+    this.severityCount$ = this.table.severityCount$;
+  }
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -20,20 +20,9 @@ export class PhaseBugReportingComponent implements OnInit {
 
   constructor(public permissions: PermissionService, public userService: UserService) {}
 
-  ngOnInit() {
-    this.typeCount = this.table.typeCount;
-    this.severityCount = this.table.severityCount;
-  }
+  ngOnInit() {}
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;
-  }
-
-  updateCount() {
-    this.typeCount = this.table.typeCount;
-    this.severityCount = this.table.severityCount;
-    console.log('EVENT DETECTED');
-    console.log(this.typeCount);
-    console.log(this.severityCount);
   }
 }

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -47,8 +47,11 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   issues: IssuesDataTable;
   issuesPendingDeletion: { [id: number]: boolean };
 
-  typeCount = new BehaviorSubject(new Map<string, number>());
-  severityCount = new BehaviorSubject(new Map<string, number>());
+  private typeCountBehaviorSubj = new BehaviorSubject(new Map<string, number>());
+  private severityCountBehaviorSubj = new BehaviorSubject(new Map<string, number>());
+
+  public typeCount$ = this.typeCountBehaviorSubj.asObservable();
+  public severityCount$ = this.severityCountBehaviorSubj.asObservable();
 
   public tableSettings: TableSettings;
 
@@ -245,8 +248,8 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
         typeCount[issue.type]++;
       }
 
-      this.typeCount.next(typeCount);
-      this.severityCount.next(severityCount);
+      this.typeCountBehaviorSubj.next(typeCount);
+      this.severityCountBehaviorSubj.next(severityCount);
     });
   }
 

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSort, Sort } from '@angular/material/sort';

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -236,16 +236,16 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
       const severityLabelStrings = this.getSeverityLabelStrings();
 
       for (let severityLabelName of severityLabelStrings) {
-        severityCount[severityLabelName] = 0;
+        severityCount.set(severityLabelName, 0);
       }
       for (let typeLabelName of typeLabelStrings) {
-        typeCount[typeLabelName] = 0;
+        typeCount.set(typeLabelName, 0);
       }
 
       // Update count
       for (let issue of data) {
-        severityCount[issue.severity]++;
-        typeCount[issue.type]++;
+        severityCount.set(issue.severity, severityCount.get(issue.severity) + 1);
+        typeCount.set(issue.type, typeCount.get(issue.type) + 1);
       }
 
       this.typeCountBehaviorSubj.next(typeCount);

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -227,21 +227,34 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
 
   getLabelsCount() {
     this.issues.connect().subscribe((data) => {
+      // Reset count
+      const typeLabelStrings = this.getTypeLabelStrings();
+      const severityLabelStrings = this.getSeverityLabelStrings();
+
+      for (let label of typeLabelStrings) {
+        this.typeCount[label] = 0;
+      }
+      for (let label of severityLabelStrings) {
+        this.severityCount[label] = 0;
+      }
+
+      // Update count
       for (let issue of data) {
         this.severityCount[issue.severity]++;
         this.typeCount[issue.type]++;
       }
 
-      this.severityCount = this.severityCount;
-      this.typeCount = this.typeCount;
+      console.log('FROM ISSUE TABLES COMPONENT:');
+      console.log(this.typeCount);
+      console.log(this.severityCount);
 
       this.countChanged.emit();
     });
   }
 
   initLabelCounts() {
-    const typeLabelStrings: string[] = this.labelService.getLabelList('type').map((label) => label.labelValue);
-    const severityLabelStrings: string[] = this.labelService.getLabelList('severity').map((label) => label.labelValue);
+    const typeLabelStrings: string[] = this.getTypeLabelStrings();
+    const severityLabelStrings: string[] = this.getSeverityLabelStrings();
 
     for (let severityLabelName of severityLabelStrings) {
       this.severityCount[severityLabelName] = 0;
@@ -251,5 +264,13 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     for (let typeLabelName of typeLabelStrings) {
       this.typeCount[typeLabelName] = 0;
     }
+  }
+
+  private getSeverityLabelStrings(): string[] {
+    return this.labelService.getLabelList('severity').map((label) => label.labelValue);
+  }
+
+  private getTypeLabelStrings(): string[] {
+    return this.labelService.getLabelList('type').map((label) => label.labelValue);
   }
 }


### PR DESCRIPTION
This feature shows a summary of the number of issues of each label at the bottom of the table, allowing students to keep track of how many issues of each type and severity they have found.

![image](https://github.com/user-attachments/assets/925c173e-a384-442f-bc88-b48fad463c2b)

The count will also be updated when a new issue is posted:

https://github.com/user-attachments/assets/8864159a-783d-42b3-b679-40fa020e4248


